### PR TITLE
Replace osgEarth ObjectLocatorNode with simVis::LocatorNode

### DIFF
--- a/Examples/RFProp/RFProp.cpp
+++ b/Examples/RFProp/RFProp.cpp
@@ -33,7 +33,6 @@
 #include "osgGA/GUIActionAdapter"
 #include "osgDB/FileUtils"
 #include "osgEarthUtil/Controls"
-#include "osgEarthUtil/ObjectLocator"
 #include "simCore/Common/HighPerformanceGraphics.h"
 #include "simCore/LUT/LUT2.h"
 #include "simCore/Calc/Angle.h"
@@ -45,6 +44,7 @@
 #include "simNotify/Notify.h"
 #include "simVis/Viewer.h"
 #include "simVis/Utils.h"
+#include "simVis/Locator.h"
 #include "simVis/RFProp/ArepsLoader.h"
 #include "simVis/RFProp/ProfileManager.h"
 #include "simVis/RFProp/LUTProfileDataProvider.h"
@@ -883,8 +883,11 @@ int main(int argc, char** argv)
   row++;
 
 
-  osg::ref_ptr<osgEarth::Util::ObjectLocatorNode> rfLocator = new ObjectLocatorNode(viewer->getSceneManager()->getMap());
-  rfLocator->getLocator()->setPosition(osg::Vec3d(lon, lat, alt));
+  osg::ref_ptr<simVis::LocatorNode> rfLocator = new simVis::LocatorNode(
+      new simVis::Locator(viewer->getSceneManager()->getMap()->getSRS()));
+  rfLocator->getLocator()->setCoordinate(simCore::Coordinate(
+      simCore::COORD_SYS_LLA,
+      simCore::Vec3(osg::DegreesToRadians(lat), osg::DegreesToRadians(lon), alt)));
   rfLocator->addChild(profileManager);
   profileManager->setRefCoord(osg::DegreesToRadians(lat), osg::DegreesToRadians(lon), alt);
   root->addChild(rfLocator);

--- a/SDK/simVis/RFProp/RFPropagationFacade.cpp
+++ b/SDK/simVis/RFProp/RFPropagationFacade.cpp
@@ -20,7 +20,6 @@
  *
  */
 #include "osg/Depth"
-#include "osgEarthUtil/ObjectLocator"
 #include "simCore/Calc/Angle.h"
 #include "simCore/EM/AntennaPattern.h"
 #include "simCore/Time/TimeClass.h"
@@ -36,6 +35,7 @@
 #include "simVis/RFProp/CompositeColorProvider.h"
 #include "simVis/RFProp/GradientColorProvider.h"
 #include "simVis/RFProp/RFPropagationFacade.h"
+#include "osgEarth/Map"
 
 namespace
 {
@@ -119,7 +119,9 @@ RFPropagationFacade::RFPropagationFacade(simData::ObjectId id, osg::Group* paren
 {
   // create locator
   if (map)
-    locator_ = new osgEarth::Util::ObjectLocatorNode(map);
+  {
+    locator_ = new simVis::LocatorNode( new simVis::Locator(map->getSRS()) );
+  }
   // add locator to the parent node
   if (locator_.valid() && parent_.valid())
     parent_->addChild(locator_);
@@ -854,8 +856,9 @@ void RFPropagationFacade::setPosition(double latRad, double lonRad)
   // locator takes lon/lat/alt, in degrees
   if (locator_)
   {
-    locator_->getLocator()->setPosition(
-      osg::Vec3d(lonRad * simCore::RAD2DEG, latRad * simCore::RAD2DEG, antennaHeight()));
+    locator_->getLocator()->setCoordinate(simCore::Coordinate(
+        simCore::COORD_SYS_LLA,
+        simCore::Vec3(latRad, lonRad, antennaHeight())));
   }
 }
 

--- a/SDK/simVis/RFProp/RFPropagationFacade.h
+++ b/SDK/simVis/RFProp/RFPropagationFacade.h
@@ -25,9 +25,9 @@
 #include <vector>
 #include <string>
 #include "osg/ref_ptr"
-#include "osgEarthUtil/ObjectLocator"
 #include "simCore/Common/Export.h"
 #include "simData/ObjectId.h"
+#include "simVis/Locator.h"
 #include "simVis/RFProp/CompositeColorProvider.h"
 #include "simVis/RFProp/ProfileDataProvider.h"
 #include "simVis/RFProp/Profile.h"
@@ -503,7 +503,7 @@ private:
   osg::ref_ptr<simRF::ProfileManager> profileManager_;
 
   /// locator node to which display is attached, and which attaches display to scene graph
-  osg::ref_ptr<osgEarth::Util::ObjectLocatorNode> locator_;
+  osg::ref_ptr<simVis::LocatorNode> locator_;
 
   /// parent node in the scene graph of our locator
   osg::observer_ptr<osg::Group> parent_;


### PR DESCRIPTION
We removed the deprecated osgEarth::Util::ObjectLocatorNode class in osgEarth. This update replaces its usage with the SDK's own simVis::LocatorNode, which has the same functionality.