### PR TITLE
osgEarth API update (after removing deprecated MapCallback functions)

### DIFF
--- a/SDK/simVis/SceneManager.h
+++ b/SDK/simVis/SceneManager.h
@@ -25,6 +25,7 @@
 #include "osg/ref_ptr"
 #include "osg/Group"
 #include "osgEarth/DrapeableNode"
+#include "osgEarth/ImageLayer"
 #include "osgEarth/MapNode"
 #include "osgEarthUtil/Sky"
 #include "osgEarthUtil/Ocean"


### PR DESCRIPTION
We removed the deprecated methods in osgEarth::MapCallback. This did not require any code changes in SDK, but did require the addition of one missing include file.