### PR TITLE
Fix build against osg master

### DIFF
--- a/SDK/simVis/Registry.cpp
+++ b/SDK/simVis/Registry.cpp
@@ -208,7 +208,7 @@ simVis::Registry::Registry()
 
   // prime a font when no fonts can be found.  This font will be invisible, but at least the program can limp along.
   osgText::Font* cantFindFont = new osgText::Font();
-#if OSG_VERSION_GREATER_OR_EQUAL(3, 4, 1) && defined(OSG_GL_FIXED_FUNCTION_AVAILABLE)
+#if OSG_VERSION_GREATER_OR_EQUAL(3, 4, 1) && OSG_VERSION_LESS_THAN(3, 7, 0) && defined(OSG_GL_FIXED_FUNCTION_AVAILABLE)
   // Remove the osgText::Font's program to avoid a bug where LDB does not apply due to conflict in programs
   if (cantFindFont->getStateSet())
     cantFindFont->getStateSet()->removeAttribute(osg::StateAttribute::PROGRAM);
@@ -402,7 +402,7 @@ osgText::Font* simVis::Registry::getOrCreateFont(const std::string& name) const
     return fontCache_.find(CANT_FIND_FONT)->second.get();
   }
 
-#if OSG_VERSION_GREATER_OR_EQUAL(3, 4, 1) && defined(OSG_GL_FIXED_FUNCTION_AVAILABLE)
+#if OSG_VERSION_GREATER_OR_EQUAL(3, 4, 1) && OSG_VERSION_LESS_THAN(3, 7, 0) && defined(OSG_GL_FIXED_FUNCTION_AVAILABLE)
   // Remove the osgText::Font's program to avoid a bug where LDB does not apply due to conflict in programs
   if (font->getStateSet())
     font->getStateSet()->removeAttribute(osg::StateAttribute::PROGRAM);


### PR DESCRIPTION
This is a fix for building against the latest osg.  The StateSet was removed on Font recently.  Branch is named fixosgearthmaster but its a fix for the master osg.