### PR TITLE
Ocean: upgrade to use SimpleOceanLayer instead of the old simple ocean node extension

### DIFF
--- a/Examples/SimpleServer/InstallOcean.cpp
+++ b/Examples/SimpleServer/InstallOcean.cpp
@@ -140,11 +140,18 @@ void InstallOcean::install(simVis::SceneManager& scene)
     osgEarth::Util::SimpleOceanLayerOptions ocean;
     // To get similar behavior as old ocean_simple driver, useBathymetry() == false helps
     ocean.useBathymetry() = false;
-#endif
     ocean.maxAltitude() = 30000.0f;
-    osg::ref_ptr<osgEarth::Util::OceanNode> oceanNode = osgEarth::Util::OceanNode::create(ocean, scene.getMapNode());
-    if (oceanNode.valid())
-      scene.setOceanNode(oceanNode.get());
+    osg::ref_ptr<osgEarth::Layer> layer = new osgEarth::Util::SimpleOceanLayer(ocean);
+
+    // Control the ocean's rendering order so we can see underwater objects:
+    layer->getOrCreateStateSet()->setRenderBinDetails(simVis::BIN_OCEAN, simVis::BIN_GLOBAL_SIMSDK);
+
+    // Do not apply the bathymetry generator when drawing the ocean surface:
+    layer->getOrCreateStateSet()->setDefine("SIMVIS_IGNORE_BATHYMETRY_GEN");
+
+    // Add to the map.
+    scene.getMap()->addLayer(layer.get());
+#endif
   }
 }
 

--- a/SDK/simVis/BathymetryGenerator.vert.glsl
+++ b/SDK/simVis/BathymetryGenerator.vert.glsl
@@ -1,6 +1,6 @@
 #version $GLSL_VERSION_STR
 
-#pragma import_defines(OE_TERRAIN_RENDER_ELEVATION)
+#pragma import_defines(SIMVIS_IGNORE_BATHYMETRY_GEN)
 
 #pragma vp_entryPoint simVis_BathymetryGenerator_vertex
 #pragma vp_location vertex_view
@@ -14,7 +14,7 @@ vec3 oe_UpVectorView; // stage global from osgEarth
 
 void simVis_BathymetryGenerator_vertex(inout vec4 vertex)
 {
-#ifdef OE_TERRAIN_RENDER_ELEVATION
+#if !defined(SIMVIS_IGNORE_BATHYMETRY_GEN)
   float elev = oe_terrain_getElevation();
   if (elev == 0.0) {
     vertex.xyz += oe_UpVectorView * simVis_BathymetryGenerator_offset;

--- a/SDK/simVis/VaporTrail.cpp
+++ b/SDK/simVis/VaporTrail.cpp
@@ -338,7 +338,7 @@ void VaporTrail::addPuff_(const simCore::Vec3& puffPosition, double puffTime)
 
   if (recyclePuffs_.empty())
   {
-    puff = new VaporTrailPuff(textures_[textureCounter_], puffMatrix, puffTime);
+    puff = new VaporTrailPuff(textures_[textureCounter_].get(), puffMatrix, puffTime);
     // add it to the group/scenegraph
     vaporTrailGroup_->addChild(puff);
   }
@@ -380,7 +380,7 @@ void VaporTrail::processTextures_(const std::vector< osg::ref_ptr<osg::Texture2D
     if (vaporTrailData_.isWake)
     {
       osg::ref_ptr<osg::Geode> geode = new osg::Geode();
-      createTexture_(*(geode.get()), *it);
+      createTexture_(*(geode.get()), (*it).get());
       // show back facing texture so that wake can be seen from under water
       geode->getOrCreateStateSet()->setAttributeAndModes(new osg::CullFace(osg::CullFace::BACK), osg::StateAttribute::OFF);
       textures_.push_back(geode);
@@ -389,7 +389,7 @@ void VaporTrail::processTextures_(const std::vector< osg::ref_ptr<osg::Texture2D
     {
       osg::ref_ptr<osg::Billboard> billboard = new osg::Billboard();
       billboard->setMode(osg::Billboard::POINT_ROT_EYE);
-      createTexture_(*(billboard.get()), *it);
+      createTexture_(*(billboard.get()), (*it).get());
       textures_.push_back(billboard);
     }
   }

--- a/SDK/simVis/View.cpp
+++ b/SDK/simVis/View.cpp
@@ -157,7 +157,7 @@ struct SetNearFarCallback : public osg::NodeCallback
     if (cv)
     {
       cv->popStateSet();
-      osg::Vec3d eye = osg::Vec3d(0, 0, 0)* cv->getCurrentCamera()->getInverseViewMatrix(); //cv->getCurrentCamera()->getViewMatrix().getTrans(); //osg::Vec3d(0,0,0)*(*cv->getModelViewMatrix());
+      osg::Vec3d eye = osg::Vec3d(0, 0, 0)* cv->getCurrentCamera()->getInverseViewMatrix();
       double eyeR = eye.length();
       const double earthR = simCore::EARTH_RADIUS;
       double eyeAlt = std::max(0.0, eyeR - earthR);


### PR DESCRIPTION
I updated ExampleOcean and InstallOcean to use a SimpleOceanLayer. I attempted to honor the SDK_OSGEARTH_VERSION_LESS_THAN conditional at least enough to get it to compile but not sure it's correct.