### PR TITLE
Fix SIM-9194: basicviewertext example crashed on exit

### DIFF
--- a/Examples/BasicViewerText/BasicViewerText.cpp
+++ b/Examples/BasicViewerText/BasicViewerText.cpp
@@ -277,8 +277,8 @@ int main(int argc, char** argv)
     props->mutable_classification()->set_label("UNCLASSIFIED");
     txn.complete(&props);
   }
-  simVis::ClassificationBanner banner(&dataStore, 24, "arialbd.ttf");
-  banner.addToView(superHUD);
+  osg::ref_ptr<simVis::ClassificationBanner> banner = new simVis::ClassificationBanner(&dataStore, 24, "arialbd.ttf");
+  banner->addToView(superHUD);
 
   // Add a help control
   superHUD->addOverlayControl(createHelp());


### PR DESCRIPTION
...because ClassificationBanner (which inherits from osg::Group) was constructed on the stack, added to the scene graph, and then destructed from the stack. Never allocate OSG nodes on the stack!