### PR TITLE
DisableDepthOnAlpha: fixed incorrect setValues logic that was causing…

### DIFF
--- a/SDK/simVis/DisableDepthOnAlpha.cpp
+++ b/SDK/simVis/DisableDepthOnAlpha.cpp
@@ -61,7 +61,7 @@ void DisableDepthOnAlpha::setValues(osg::StateSet* stateset, int value)
   int over = value & osg::StateAttribute::OVERRIDE;
   int prot = value & osg::StateAttribute::PROTECTED;
 
-  int negValue = (value | osg::StateAttribute::ON)?
+  int negValue = (value & osg::StateAttribute::ON)?
       osg::StateAttribute::OFF | over | prot :
       osg::StateAttribute::ON | over | prot;
 

--- a/SDK/simVis/DisableDepthOnAlpha.cpp
+++ b/SDK/simVis/DisableDepthOnAlpha.cpp
@@ -57,7 +57,15 @@ void DisableDepthOnAlpha::setValues(osg::StateSet* stateset, int value)
 {
   if (stateset == NULL)
     return;
-  stateset->setDefine(USE_DISABLE_DEPTH_DEFINE, value);
+
+  int over = value & osg::StateAttribute::OVERRIDE;
+  int prot = value & osg::StateAttribute::PROTECTED;
+
+  int negValue = (value | osg::StateAttribute::ON)?
+      osg::StateAttribute::OFF | over | prot :
+      osg::StateAttribute::ON | over | prot;
+
+  stateset->setDefine(USE_DISABLE_DEPTH_DEFINE, negValue);
 }
 
 }


### PR DESCRIPTION
… icons and model to accidentally bypass the disable depth shader