### PR TITLE
RadialLOS: performance improvement

### DIFF
--- a/SDK/simVis/RadialLOS.h
+++ b/SDK/simVis/RadialLOS.h
@@ -231,6 +231,7 @@ private:
   osgEarth::Angle     fov_;
   osgEarth::Angle     azim_resolution_;
   osg::ref_ptr<const osgEarth::SpatialReference> srs_;
+  osg::ref_ptr<osgEarth::ElevationEnvelope> envelope_;
 
   bool getBoundingRadials_(double azim_rad, const Radial*& out_r0, const Radial*& out_r1, double& out_mix) const;
 


### PR DESCRIPTION
This changes RadialLOS (data computer) to use the osgEarth ElevationPool instead of terrain intersections. This is faster, especially when recomputing the RLOS when eye position changes. At higher zoom levels the improvement reached up to 10x.

I did not remove the code that listens for terrain tile changes and fires off a recompute -- but I did comment out the code in RadialLOS that performs that recompute because it's no longer necessary. If we decide to keep this approach and discard the old one, I will remove all that code. I also need to put in a calculate for HAMSL versus HAE.
