### PR TITLE
simVis::View::getLighting bug

### DIFF
--- a/SDK/simVis/View.cpp
+++ b/SDK/simVis/View.cpp
@@ -1150,6 +1150,11 @@ void View::setLighting(bool value)
   lighting_ = value;
 }
 
+bool View::getLighting() const
+{
+  return lighting_;
+}
+
 double View::fovX() const
 {
   return fovXDeg_;


### PR DESCRIPTION
Bug in simVis::View::getLighting where it was declared, but not defined.