### PR TITLE
Don't include Examples/Ocean if Triton is not found

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -19,7 +19,11 @@ add_subdirectory(ImageIcons)
 add_subdirectory(MapScale)
 add_subdirectory(MassiveData)
 add_subdirectory(ObserverMaker)
-add_subdirectory(Ocean)
+
+if(HAVE_OSGEARTH_TRITON)
+    add_subdirectory(Ocean)
+endif()
+
 add_subdirectory(Overhead)
 add_subdirectory(Periscope)
 add_subdirectory(Picking)


### PR DESCRIPTION
Check if Triton SDK was found before trying to include the Examples/Ocean sub project.  Including Examples/Ocean errors out if included and TritonSDK is not available.