### PR TITLE
Add a missing header when installing the SDK via make install

### DIFF
--- a/SDK/simVis/CMakeLists.txt
+++ b/SDK/simVis/CMakeLists.txt
@@ -181,6 +181,7 @@ set(VIS_HEADERS_GOG
     ${VIS_INC}GOG/Ellipse.h
     ${VIS_INC}GOG/Ellipsoid.h
     ${VIS_INC}GOG/ErrorHandler.h
+    ${VIS_INC}GOG/GenericGeometry.h
     ${VIS_INC}GOG/GOG.h
     ${VIS_INC}GOG/GOGNode.h
     ${VIS_INC}GOG/GogNodeInterface.h


### PR DESCRIPTION
When running `make install` the header file `simVis/GOG/GenericGeometry.h` is not installed as part of the target.  Patch adds missing header to the CMakeLists.txt header.