### PR TITLE
Projectors - bug fixes and features

### DIFF
--- a/SDK/simData/GeneratedCode/simData.proto
+++ b/SDK/simData/GeneratedCode/simData.proto
@@ -1371,6 +1371,8 @@ message ProjectorPrefs {
   optional bool shadowMapping = 8 [default = false];
   /// Maximum distance from projector at which to draw projected image (<=0 means no limiting)
   optional float maxDrawRange = 9 [default = 0.0];
+  /// Whether to project on backfacing geometry as well as front
+  optional bool doubleSided = 10 [default = false];
 };
 
 /// common update to projector data

--- a/SDK/simVis/PlanetariumViewTool.cpp
+++ b/SDK/simVis/PlanetariumViewTool.cpp
@@ -1052,6 +1052,7 @@ void PlanetariumViewTool::updateDome_()
     dome_->setName("Planetarium Sphere Geometry");
     osg::StateSet* stateSet = dome_->getOrCreateStateSet();
     stateSet->setMode(GL_BLEND, 1);
+    stateSet->setMode(GL_CULL_FACE, 0 | osg::StateAttribute::PROTECTED);
     // Turn off the depth writes to help with transparency
     stateSet->setAttributeAndModes(new osg::Depth(osg::Depth::LEQUAL, 0, 1, false));
     locatorRoot_->addChild(dome_.get());

--- a/SDK/simVis/Projector.frag.glsl
+++ b/SDK/simVis/Projector.frag.glsl
@@ -9,6 +9,7 @@ uniform sampler2D simProjSampler;
 uniform bool projectorUseColorOverride;
 uniform vec4 projectorColorOverride;
 uniform float projectorMaxRangeSquared;
+uniform bool projectorDoubleSided;
 
 in vec3 vp_Normal;
 in vec3 oe_UpVectorView;
@@ -73,11 +74,16 @@ void sim_proj_frag(inout vec4 color)
 
 #endif // SIMVIS_PROJECT_USE_SHADOWMAP
 
-  // don't draw over the horizon or on any back-facing surface
-  float vis = -vert_dot_normal;
-  if (vis <= 0.0 && fail_mix < 1.0) {
+  float vis;
+
+  // don't draw on any back-facing surface
+  if (!projectorDoubleSided)
+  {
+    vis = -vert_dot_normal;
+    if (vis <= 0.0 && fail_mix < 1.0) {
       fail_mix = 1.0;
       fail_color = vec4(1, 1, 0, 1);
+    }
   }
 
   // don't draw on geometry whose plane is very close to the projection vector

--- a/SDK/simVis/Projector.h
+++ b/SDK/simVis/Projector.h
@@ -291,6 +291,7 @@ private:
   osg::ref_ptr<osg::Uniform> useColorOverrideUniform_;
   osg::ref_ptr<osg::Uniform> colorOverrideUniform_;
   osg::ref_ptr<osg::Uniform> projectorMaxRangeSquaredUniform_;
+  osg::ref_ptr<osg::Uniform> doubleSidedUniform_;
 
   // Keep track of the nodes projected onto so the projections can be removed when projector is deleted.
   // The key is the entity the value is the attachment point


### PR DESCRIPTION
- Added the `doublesided` property to ProjectorPrefs to toggle whether to project on to backfacing polygons. Default is false. Enabling this will let you project on the interior of a planetarium sphere
- Fixed the ProjectOnEntity.glsl shader to consider the same constraints as the terrain projection shader, namely backfacing polygons and max range, which were not being considered before.