### PR TITLE
Fix an issue with projector shadow maps

### DIFF
--- a/SDK/simVis/Projector.cpp
+++ b/SDK/simVis/Projector.cpp
@@ -1076,6 +1076,7 @@ void ProjectorNode::setMapNode(osgEarth::MapNode* mapNode)
     if (mapNode)
     {
       shadowCam_->addChild(mapNode->getTerrainEngine()->getNode());
+      shadowCam_->setRenderingCache(nullptr);
     }
   }
 }


### PR DESCRIPTION
Reloading the map would cause them to cease functioning and the projector to disappear.
The fix is to reset OSG's render stage cache after setting the new map node.