### PR TITLE
Synchronize with osgEarth update to Units API

### DIFF
--- a/Examples/GOGReader/GOGReader.cpp
+++ b/Examples/GOGReader/GOGReader.cpp
@@ -30,7 +30,6 @@
 #include <vector>
 #include "osgEarth/Controls"
 #include "osgEarth/LabelNode"
-#include "osgEarth/MouseCoordsTool"
 #include "osgEarth/NodeUtils"
 #include "osgEarth/optional"
 #include "osgEarth/PlaceNode"

--- a/SDK/simUtil/UnitTypeConverter.cpp
+++ b/SDK/simUtil/UnitTypeConverter.cpp
@@ -27,7 +27,7 @@
 
 namespace simUtil {
 
-static const osgEarth::Units OSGEARTH_NONE;
+static const osgEarth::UnitsType OSGEARTH_NONE;
 
 /**
  * Helper class to UnitTypeConverter that stores the mappings from each
@@ -42,7 +42,7 @@ public:
   }
 
   /** Adds a mapping. */
-  void add(const osgEarth::Units& osg, const simCore::Units& core, int data)
+  void add(const osgEarth::UnitsType& osg, const simCore::Units& core, int data)
   {
     // No way to add new families in osgEarth, so we can't test getType()
     const bool osgValid = !osg.getName().empty();
@@ -78,7 +78,7 @@ public:
   }
 
   /** Retrieve the simCore units */
-  const simCore::Units& toCore(const osgEarth::Units& osg) const
+  const simCore::Units& toCore(const osgEarth::UnitsType& osg) const
   {
     auto i = osgEarthToCore_.find(osg.getName());
     if (i == osgEarthToCore_.end())
@@ -96,7 +96,7 @@ public:
   }
 
   /** Retrieve the simData units */
-  int toData(const osgEarth::Units& osg) const
+  int toData(const osgEarth::UnitsType& osg) const
   {
     auto i = osgEarthToData_.find(osg.getName());
     if (i == osgEarthToData_.end())
@@ -114,7 +114,7 @@ public:
   }
 
   /** Retrieve the osgEarth units */
-  const osgEarth::Units& toOsgEarth(const simCore::Units& core) const
+  const osgEarth::UnitsType& toOsgEarth(const simCore::Units& core) const
   {
     auto i = coreToOsgEarth_.find(core.name());
     if (i == coreToOsgEarth_.end())
@@ -123,7 +123,7 @@ public:
   }
 
   /** Retrieve the osgEarth units */
-  const osgEarth::Units& toOsgEarth(int data) const
+  const osgEarth::UnitsType& toOsgEarth(int data) const
   {
     auto i = dataToOsgEarth_.find(data);
     if (i == dataToOsgEarth_.end())
@@ -146,9 +146,9 @@ private:
   std::map<std::string, int> osgEarthToData_;
   std::map<std::string, int> coreToData_;
 
-  std::map<std::string, osgEarth::Units> coreToOsgEarth_;
-  std::map<int, osgEarth::Units> dataToOsgEarth_;
-  const osgEarth::Units osgEarthInvalid_;
+  std::map<std::string, osgEarth::UnitsType> coreToOsgEarth_;
+  std::map<int, osgEarth::UnitsType> dataToOsgEarth_;
+  const osgEarth::UnitsType osgEarthInvalid_;
   const simCore::Units simCoreInvalid_;
 };
 
@@ -265,37 +265,37 @@ UnitTypeConverter::~UnitTypeConverter()
 {
 }
 
-const osgEarth::Units& UnitTypeConverter::toOsgEarth(const simCore::Units& core) const
+const osgEarth::UnitsType& UnitTypeConverter::toOsgEarth(const simCore::Units& core) const
 {
   return helper_->toOsgEarth(core);
 }
 
-const osgEarth::Units& UnitTypeConverter::toOsgEarth(simData::ElapsedTimeFormat data) const
+const osgEarth::UnitsType& UnitTypeConverter::toOsgEarth(simData::ElapsedTimeFormat data) const
 {
   return helper_->toOsgEarth(data);
 }
 
-const osgEarth::Units& UnitTypeConverter::toOsgEarth(simData::AngleUnits data) const
+const osgEarth::UnitsType& UnitTypeConverter::toOsgEarth(simData::AngleUnits data) const
 {
   return helper_->toOsgEarth(data);
 }
 
-const osgEarth::Units& UnitTypeConverter::toOsgEarth(simData::DistanceUnits data) const
+const osgEarth::UnitsType& UnitTypeConverter::toOsgEarth(simData::DistanceUnits data) const
 {
   return helper_->toOsgEarth(data);
 }
 
-const osgEarth::Units& UnitTypeConverter::toOsgEarth(simData::SpeedUnits data) const
+const osgEarth::UnitsType& UnitTypeConverter::toOsgEarth(simData::SpeedUnits data) const
 {
   return helper_->toOsgEarth(data);
 }
 
-const osgEarth::Units& UnitTypeConverter::toOsgEarthFromData(int data) const
+const osgEarth::UnitsType& UnitTypeConverter::toOsgEarthFromData(int data) const
 {
   return helper_->toOsgEarth(data);
 }
 
-const simCore::Units& UnitTypeConverter::toCore(const osgEarth::Units& osg) const
+const simCore::Units& UnitTypeConverter::toCore(const osgEarth::UnitsType& osg) const
 {
   return helper_->toCore(osg);
 }
@@ -325,7 +325,7 @@ const simCore::Units& UnitTypeConverter::toCoreFromData(int data) const
   return helper_->toCore(data);
 }
 
-int UnitTypeConverter::toData(const osgEarth::Units& osg) const
+int UnitTypeConverter::toData(const osgEarth::UnitsType& osg) const
 {
   return helper_->toData(osg);
 }
@@ -340,12 +340,12 @@ bool UnitTypeConverter::isRegistered(const simCore::Units& units) const
   return helper_->isRegistered(units);
 }
 
-void UnitTypeConverter::addMapping(const osgEarth::Units& osg, const simCore::Units& core, int data)
+void UnitTypeConverter::addMapping(const osgEarth::UnitsType& osg, const simCore::Units& core, int data)
 {
   helper_->add(osg, core, data);
 }
 
-void UnitTypeConverter::addMapping(const osgEarth::Units& osg, const simCore::Units& core)
+void UnitTypeConverter::addMapping(const osgEarth::UnitsType& osg, const simCore::Units& core)
 {
   addMapping(osg, core, 0);
 }
@@ -355,7 +355,7 @@ void UnitTypeConverter::addMapping(const simCore::Units& core, int data)
   addMapping(OSGEARTH_NONE, core, data);
 }
 
-void UnitTypeConverter::addMapping(const osgEarth::Units& osg, int data)
+void UnitTypeConverter::addMapping(const osgEarth::UnitsType& osg, int data)
 {
   addMapping(osg, simCore::Units::UNITLESS, data);
 }

--- a/SDK/simUtil/UnitTypeConverter.h
+++ b/SDK/simUtil/UnitTypeConverter.h
@@ -27,7 +27,7 @@
 #include "simCore/Common/Common.h"
 #include "simData/DataTypes.h"
 
-namespace osgEarth { class Units; }
+namespace osgEarth { class UnitsType; }
 namespace simCore { class Units; }
 
 namespace simUtil {
@@ -40,20 +40,20 @@ public:
   virtual ~UnitTypeConverter();
 
   /** Returns an osgEarth::Units mapped from the simCore::Units provided; empty string name on error. */
-  const osgEarth::Units& toOsgEarth(const simCore::Units& core) const;
+  const osgEarth::UnitsType& toOsgEarth(const simCore::Units& core) const;
   /** Returns an osgEarth::Units mapped from the simData units provided; empty string name on error. */
-  const osgEarth::Units& toOsgEarth(simData::ElapsedTimeFormat data) const;
+  const osgEarth::UnitsType& toOsgEarth(simData::ElapsedTimeFormat data) const;
   /** Returns an osgEarth::Units mapped from the simData units provided; empty string name on error. */
-  const osgEarth::Units& toOsgEarth(simData::AngleUnits data) const;
+  const osgEarth::UnitsType& toOsgEarth(simData::AngleUnits data) const;
   /** Returns an osgEarth::Units mapped from the simData units provided; empty string name on error. */
-  const osgEarth::Units& toOsgEarth(simData::DistanceUnits data) const;
+  const osgEarth::UnitsType& toOsgEarth(simData::DistanceUnits data) const;
   /** Returns an osgEarth::Units mapped from the simData units provided; empty string name on error. */
-  const osgEarth::Units& toOsgEarth(simData::SpeedUnits data) const;
+  const osgEarth::UnitsType& toOsgEarth(simData::SpeedUnits data) const;
   /** Returns an osgEarth::Units mapped from the simData units provided; empty string name on error. */
-  const osgEarth::Units& toOsgEarthFromData(int data) const;
+  const osgEarth::UnitsType& toOsgEarthFromData(int data) const;
 
   /** Returns a simCore::Units mapped from the osgEarth::Units provided; !isValid() on error. */
-  const simCore::Units& toCore(const osgEarth::Units& osg) const;
+  const simCore::Units& toCore(const osgEarth::UnitsType& osg) const;
   /** Returns a simCore::Units mapped from the simData::ElapsedTimeFormat provided; !isValid() on error, but should not error. */
   const simCore::Units& toCore(simData::ElapsedTimeFormat data) const;
   /** Returns a simCore::Units mapped from the simData::AngleUnits provided; !isValid() on error, but should not error. */
@@ -66,18 +66,18 @@ public:
   const simCore::Units& toCoreFromData(int data) const;
 
   /** Returns an simData units value mapped from the osgEarth::Units provided; 0 (CU_UNKNOWN) on error. */
-  int toData(const osgEarth::Units& osg) const;
+  int toData(const osgEarth::UnitsType& osg) const;
   /** Returns an simData units value mapped from the simCore::Units provided; 0 (CU_UNKNOWN) on error. */
   int toData(const simCore::Units& core) const;
 
   /** Convenience to add a new mapping */
-  void addMapping(const osgEarth::Units& osg, const simCore::Units& core, int data);
+  void addMapping(const osgEarth::UnitsType& osg, const simCore::Units& core, int data);
   /** Convenience to add a new mapping without valid data enum */
-  void addMapping(const osgEarth::Units& osg, const simCore::Units& core);
+  void addMapping(const osgEarth::UnitsType& osg, const simCore::Units& core);
   /** Convenience to add a new mapping without valid osgEarth enum */
   void addMapping(const simCore::Units& core, int data);
   /** Convenience to add a new mapping without valid simCore enum */
-  void addMapping(const osgEarth::Units& osg, int data);
+  void addMapping(const osgEarth::UnitsType& osg, int data);
 
   /** Helper method to determine if a given unit is registered with this system.  Useful for unit tests. */
   bool isRegistered(const simCore::Units& units) const;

--- a/SDK/simVis/LocalGrid.cpp
+++ b/SDK/simVis/LocalGrid.cpp
@@ -98,7 +98,7 @@ public:
   CartesianGridLabel(const simData::LocalGridPrefs& prefs, float valM) : LocalGridLabel(prefs)
   {
     std::stringstream buf;
-    const osgEarth::Units& prefSizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
+    const osgEarth::UnitsType& prefSizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
     const double gridScale = osgEarth::Units::METERS.convertTo(prefSizeUnits, valM);
     buf << std::fixed << std::setprecision(prefs.gridlabelprecision()) << gridScale << ' ' << prefSizeUnits.getAbbr();
     setText(buf.str());
@@ -188,7 +188,7 @@ public:
     const float radiusM = spacingM * (ring_ + 1);
 
     // displaying distance, not time; convert labels value from meters to local grid units pref
-    const osgEarth::Units& prefSizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
+    const osgEarth::UnitsType& prefSizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
     const double radius = osgEarth::Units::METERS.convertTo(prefSizeUnits, radiusM);
     std::stringstream buf;
     buf << std::fixed << std::setprecision(prefs.gridlabelprecision()) << radius << ' ' << prefSizeUnits.getAbbr();
@@ -620,7 +620,7 @@ void LocalGridNode::configureLocator_(const simData::LocalGridPrefs& prefs)
   if (prefs.has_gridpositionoffset())
   {
     const simData::Position& pos = prefs.gridpositionoffset();
-    const osgEarth::Units& sizeUnits = simVis::convertUnitsToOsgEarth(prefs.positionoffsetunits());
+    const osgEarth::UnitsType& sizeUnits = simVis::convertUnitsToOsgEarth(prefs.positionoffsetunits());
     const float x = sizeUnits.convertTo(osgEarth::Units::METERS, pos.x());
     const float y = sizeUnits.convertTo(osgEarth::Units::METERS, pos.y());
     const float z = sizeUnits.convertTo(osgEarth::Units::METERS, pos.z());
@@ -665,7 +665,7 @@ void LocalGridNode::syncWithLocator()
 // creates a Cartesian grid.
 void LocalGridNode::createCartesian_(const simData::LocalGridPrefs& prefs, osg::Group* geomGroup, osg::Group* labelGroup) const
 {
-  const osgEarth::Units& sizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
+  const osgEarth::UnitsType& sizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
   // Note that size is halved; it's provided in diameter, and we need it as radius
   const float size = sizeUnits.convertTo(osgEarth::Units::METERS, prefs.size()) * 0.5f;
   const int numDivisions    = prefs.gridsettings().numdivisions();
@@ -747,7 +747,7 @@ void LocalGridNode::createCartesian_(const simData::LocalGridPrefs& prefs, osg::
 // creates a range-rings local grid with optional polar radials.
 void LocalGridNode::createRangeRings_(const simData::LocalGridPrefs& prefs, osg::Group* geomGroup, osg::Group* labelGroup, bool includePolarRadials) const
 {
-  const osgEarth::Units& sizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
+  const osgEarth::UnitsType& sizeUnits = simVis::convertUnitsToOsgEarth(prefs.sizeunits());
   // Note that size is halved; it's provided in diameter, and we need it as radius
   const float sizeM = sizeUnits.convertTo(osgEarth::Units::METERS, prefs.size()) * 0.5f;
 
@@ -956,7 +956,7 @@ int LocalGridNode::processSpeedParams_(const simData::LocalGridPrefs& prefs, dou
   else if (prefs.speedring().speedtouse() > 0.0)
   {
     // using speedToUse, convert to m/s
-    const osgEarth::Units& prefSpeedUnits = simVis::convertUnitsToOsgEarth(prefs.speedring().speedunits());
+    const osgEarth::UnitsType& prefSpeedUnits = simVis::convertUnitsToOsgEarth(prefs.speedring().speedunits());
     speedMS = prefSpeedUnits.convertTo(osgEarth::Units::METERS_PER_SECOND, prefs.speedring().speedtouse());
     if (simCore::areEqual(speedMS, 0.0))
     {

--- a/SDK/simVis/Utils.cpp
+++ b/SDK/simVis/Utils.cpp
@@ -389,7 +389,7 @@ bool isImageFile(const std::string& location)
   return false;
 }
 
-osgEarth::Units convertUnitsToOsgEarth(const simData::DistanceUnits& input)
+osgEarth::UnitsType convertUnitsToOsgEarth(const simData::DistanceUnits& input)
 {
     return
         input == simData::UNITS_CENTIMETERS    ? osgEarth::Units::CENTIMETERS :
@@ -405,10 +405,10 @@ osgEarth::Units convertUnitsToOsgEarth(const simData::DistanceUnits& input)
         input == simData::UNITS_MILLIMETERS    ? osgEarth::Units::MILLIMETERS :
         input == simData::UNITS_NAUTICAL_MILES ? osgEarth::Units::NAUTICAL_MILES :
         input == simData::UNITS_YARDS          ? osgEarth::Units::YARDS :
-        osgEarth::Units(); // invalid
+        osgEarth::UnitsType(); // invalid
 }
 
-osgEarth::Units convertUnitsToOsgEarth(const simData::SpeedUnits& input)
+osgEarth::UnitsType convertUnitsToOsgEarth(const simData::SpeedUnits& input)
 {
     return
         input == simData::UNITS_METERS_PER_SECOND     ? osgEarth::Units::METERS_PER_SECOND :
@@ -419,7 +419,7 @@ osgEarth::Units convertUnitsToOsgEarth(const simData::SpeedUnits& input)
         input == simData::UNITS_KILOMETERS_PER_SECOND ? osgEarth::Units::KILOMETERS_PER_SECOND :
         input == simData::UNITS_DATAMILES_PER_HOUR    ? osgEarth::Units::DATA_MILES_PER_HOUR :
         input == simData::UNITS_YARDS_PER_SECOND      ? osgEarth::Units::YARDS_PER_SECOND :
-        osgEarth::Units(); // invalid
+        osgEarth::UnitsType(); // invalid
 }
 
 void iconAlignmentToOffsets(simData::TextAlignment align, const osg::Vec2f& iconDims, osg::Vec2f& outOffsets)

--- a/SDK/simVis/Utils.h
+++ b/SDK/simVis/Utils.h
@@ -258,12 +258,12 @@ namespace simVis
   /**
    * Convert simData DistanceUnits to osgEarth::Units.
    */
-  SDKVIS_EXPORT osgEarth::Units convertUnitsToOsgEarth(const simData::DistanceUnits& input);
+  SDKVIS_EXPORT osgEarth::UnitsType convertUnitsToOsgEarth(const simData::DistanceUnits& input);
 
   /**
    * Convert simData SpeedUnits to osgEarth::Units.
    */
-  SDKVIS_EXPORT osgEarth::Units convertUnitsToOsgEarth(const simData::SpeedUnits& input);
+  SDKVIS_EXPORT osgEarth::UnitsType convertUnitsToOsgEarth(const simData::SpeedUnits& input);
 
   /** Given an icon alignment and image size, gives offsets from center. */
   SDKVIS_EXPORT void iconAlignmentToOffsets(simData::TextAlignment align, const osg::Vec2f& iconDims, osg::Vec2f& outOffsets);

--- a/SDK/simVis/VelocityVector.cpp
+++ b/SDK/simVis/VelocityVector.cpp
@@ -173,7 +173,7 @@ void VelocityVector::createVelocityVector_(const simData::PlatformPrefs& prefs, 
   if (prefs.velvecusestaticlength())
   {
     velocity = lla.velocity().normalize();
-    const osgEarth::Units sizeUnits = simVis::convertUnitsToOsgEarth(prefs.velvecstaticlenunits());
+    const osgEarth::UnitsType sizeUnits = simVis::convertUnitsToOsgEarth(prefs.velvecstaticlenunits());
     scale = sizeUnits.convertTo(osgEarth::Units::METERS, prefs.velvecstaticlen());
   }
   else

--- a/Testing/SimUtil/UnitTypeConverterTest.cpp
+++ b/Testing/SimUtil/UnitTypeConverterTest.cpp
@@ -130,7 +130,7 @@ int testFromOsgEarth()
 int testFromData()
 {
   int rv = 0;
-  const osgEarth::Units OSGEARTH_NONE;
+  const osgEarth::UnitsType OSGEARTH_NONE;
   simUtil::UnitTypeConverter conv;
 
   // time to osgEarth
@@ -219,7 +219,7 @@ int testFromData()
 int testFromCore()
 {
   int rv = 0;
-  const osgEarth::Units OSGEARTH_NONE;
+  const osgEarth::UnitsType OSGEARTH_NONE;
   simUtil::UnitTypeConverter conv;
 
   // Distance to osgEarth
@@ -326,7 +326,7 @@ int testAddMapping()
   simUtil::UnitTypeConverter conv;
   const simCore::Units coreDbsm("dBsm", "dBsm", 1.0, "dBsm");
   const simCore::Units corePercent("percent", "%", 1.0, "percent");
-  const osgEarth::Units OSGEARTH_NONE;
+  const osgEarth::UnitsType OSGEARTH_NONE;
 
   // Should not recognize the unit ahead of time
   rv += SDK_ASSERT(!conv.isRegistered(coreDbsm));


### PR DESCRIPTION
The osgEarth::Units API changed to support better static initialization. This PR updates SIM SDK with the new osgEarth::UnitsType type where appropriate.