### PR TITLE
Integrate new osgEarthImGui nodekit

### DIFF
--- a/CMakeImport/ImportOSGEarth.cmake
+++ b/CMakeImport/ImportOSGEarth.cmake
@@ -76,6 +76,12 @@ elseif(EXISTS "${${LIBRARYNAME}_LIBRARY_INCLUDE_PATH}/osgEarthTriton/TritonOptio
     list(APPEND SUBLIBRARY_NAMES Triton)
 endif()
 
+# osgEarthImGui added in osgEarth SOVERSION 159
+if(EXISTS "${${LIBRARYNAME}_LIBRARY_INCLUDE_PATH}/osgEarthImGui/ImGuiPanel")
+    set(HAVE_OSGEARTH_IMGUI_NODEKIT TRUE)
+    list(APPEND SUBLIBRARY_NAMES ImGui)
+endif()
+
 # Internal macro to import osgEarth libraries.  NAME can be empty string, Util, Symbology, etc.
 macro(import_osgearth_lib NAMEVAL)
     if("${NAMEVAL}" STREQUAL "")

--- a/Examples/imgui/BaseGui.cpp
+++ b/Examples/imgui/BaseGui.cpp
@@ -21,7 +21,6 @@
  *
  */
 #include "imgui.h"
-#include "osgEarth/ImGui/ImGui"
 #include "BaseGui.h"
 
 namespace GUI {

--- a/Examples/imgui/BaseGui.h
+++ b/Examples/imgui/BaseGui.h
@@ -25,7 +25,6 @@
 
 #include "imgui.h"
 #include "imgui_internal.h"
-#include "osgEarth/ImGui/ImGui"
 #include <string>
 
 struct ImFont;

--- a/Examples/imgui/OsgImGuiHandler.cpp
+++ b/Examples/imgui/OsgImGuiHandler.cpp
@@ -30,8 +30,16 @@
 #include "osgEarth/Version"
 #include "osgEarth/ShaderLoader"
 #include "osgEarth/VirtualProgram"
-#include "osgEarth/ImGui/CameraGUI"
-#include "osgEarth/ImGui/EnvironmentGUI"
+
+#if OSGEARTH_SOVERSION >= 159
+  #include "osgEarthImGui/CameraGUI"
+  #include "osgEarthImGui/EnvironmentGUI"
+  using namespace osgEarth;
+#else
+  #include "osgEarth/ImGui/CameraGUI"
+  #include "osgEarth/ImGui/EnvironmentGUI"
+  using namespace osgEarth::GUI;
+#endif
 
 #if OSGEARTH_SOVERSION < 146
 #undef NOMINMAX
@@ -43,20 +51,35 @@
 using AnnotationData = osgEarth::AnnotationData;
 using EarthManipulator = osgEarth::EarthManipulator;
 
-#include "osgEarth/ImGui/AnnotationsGUI"
+  #if OSGEARTH_SOVERSION >= 159
+    #include "osgEarthImGui/AnnotationsGUI"
+  #else
+    #include "osgEarth/ImGui/AnnotationsGUI"
+  #endif
 #endif
 
 #if 0
 #include "osgEarth/ImGui/LayersGUI"
 #endif
 
-#include "osgEarth/ImGui/NetworkMonitorGUI"
-#include "osgEarth/ImGui/RenderingGUI"
-#include "osgEarth/ImGui/SceneGraphGUI"
-#include "osgEarth/ImGui/SystemGUI"
-#include "osgEarth/ImGui/TerrainGUI"
-#include "osgEarth/ImGui/TextureInspectorGUI"
-#include "osgEarth/ImGui/ViewpointsGUI"
+#if OSGEARTH_SOVERSION >= 159
+  #include "osgEarthImGui/NetworkMonitorGUI"
+  #include "osgEarthImGui/RenderingGUI"
+  #include "osgEarthImGui/SceneGraphGUI"
+  #include "osgEarthImGui/SystemGUI"
+  #include "osgEarthImGui/TerrainGUI"
+  #include "osgEarthImGui/TextureInspectorGUI"
+  #include "osgEarthImGui/ViewpointsGUI"
+#else
+  #include "osgEarth/ImGui/NetworkMonitorGUI"
+  #include "osgEarth/ImGui/RenderingGUI"
+  #include "osgEarth/ImGui/SceneGraphGUI"
+  #include "osgEarth/ImGui/SystemGUI"
+  #include "osgEarth/ImGui/TerrainGUI"
+  #include "osgEarth/ImGui/TextureInspectorGUI"
+  #include "osgEarth/ImGui/ViewpointsGUI"
+#endif
+
 #include "simNotify/Notify.h"
 #include "simCore/Calc/Interpolation.h"
 #include "simVis/Registry.h"
@@ -127,30 +150,38 @@ OsgImGuiHandler::OsgImGuiHandler()
   autoAdjustProjectionMatrix_(true)
 {
 #if OSGEARTH_SOVERSION >= 148
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::AnnotationsGUI>(new osgEarth::GUI::AnnotationsGUI));
+  menus_["Tools"].push_back(std::unique_ptr<AnnotationsGUI>(new AnnotationsGUI));
 #endif
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::CameraGUI>(new osgEarth::GUI::CameraGUI));
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::EnvironmentGUI>(new osgEarth::GUI::EnvironmentGUI));
+  menus_["Tools"].push_back(std::unique_ptr<CameraGUI>(new CameraGUI));
+  menus_["Tools"].push_back(std::unique_ptr<EnvironmentGUI>(new EnvironmentGUI));
 #if 0
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::LayersGUI>(new osgEarth::GUI::LayersGUI));
+  menus_["Tools"].push_back(std::unique_ptr<LayersGUI>(new LayersGUI));
 #endif
 
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::NetworkMonitorGUI>(new osgEarth::GUI::NetworkMonitorGUI));
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::NVGLInspectorGUI>(new osgEarth::GUI::NVGLInspectorGUI));
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::RenderingGUI>(new osgEarth::GUI::RenderingGUI));
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::SceneGraphGUI>(new osgEarth::GUI::SceneGraphGUI));
+  menus_["Tools"].push_back(std::unique_ptr<NetworkMonitorGUI>(new NetworkMonitorGUI));
+  menus_["Tools"].push_back(std::unique_ptr<NVGLInspectorGUI>(new NVGLInspectorGUI));
+  menus_["Tools"].push_back(std::unique_ptr<RenderingGUI>(new RenderingGUI));
+  menus_["Tools"].push_back(std::unique_ptr<SceneGraphGUI>(new SceneGraphGUI));
   // Not including ShaderGUI as it expects command line arguments. Can be added later if needed
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::SystemGUI>(new osgEarth::GUI::SystemGUI));
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::TerrainGUI>(new osgEarth::GUI::TerrainGUI));
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::TextureInspectorGUI>(new osgEarth::GUI::TextureInspectorGUI));
-  menus_["Tools"].push_back(std::unique_ptr<osgEarth::GUI::ViewpointsGUI>(new osgEarth::GUI::ViewpointsGUI));
+  menus_["Tools"].push_back(std::unique_ptr<SystemGUI>(new SystemGUI));
+  menus_["Tools"].push_back(std::unique_ptr<TerrainGUI>(new TerrainGUI));
+  menus_["Tools"].push_back(std::unique_ptr<TextureInspectorGUI>(new TextureInspectorGUI));
+  menus_["Tools"].push_back(std::unique_ptr<ViewpointsGUI>(new ViewpointsGUI));
 }
 
+#if OSGEARTH_SOVERSION >= 159
+void OsgImGuiHandler::add(osgEarth::ImGuiPanel* gui)
+{
+  if (gui != nullptr)
+    menus_["User"].push_back(std::unique_ptr<ImGuiPanel>(gui));
+}
+#else
 void OsgImGuiHandler::add(osgEarth::GUI::BaseGUI* gui)
 {
   if (gui != nullptr)
     menus_["User"].push_back(std::unique_ptr<osgEarth::GUI::BaseGUI>(gui));
 }
+#endif
 
 void OsgImGuiHandler::add(::GUI::BaseGui* gui)
 {

--- a/Examples/imgui/OsgImGuiHandler.h
+++ b/Examples/imgui/OsgImGuiHandler.h
@@ -25,9 +25,11 @@
 
 #include <memory>
 #include <osgViewer/ViewerEventHandlers>
+#include <osgEarth/Version>
 
 namespace osg { class Camera; }
 namespace osgEarth { namespace GUI { class BaseGUI; } }
+namespace osgEarth { class ImGuiPanel; }
 
 struct ImFont;
 struct ImGuiSettingsHandler;
@@ -54,7 +56,12 @@ public:
   virtual bool handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& aa) override;
 
   /** Add a GUI to the manager */
+#if OSGEARTH_SOVERSION >= 159
+  void add(osgEarth::ImGuiPanel* gui);
+#else
   void add(osgEarth::GUI::BaseGUI* gui);
+#endif
+
   /** Add deprecated GUI to the manager. TODO: Remove once ::GUI::BaseGUI is removed */
   void add(::GUI::BaseGui* gui);
 
@@ -108,7 +115,12 @@ private:
   bool firstDraw_;
   bool autoAdjustProjectionMatrix_;
 
+#if OSGEARTH_SOVERSION >= 159
+  std::map<std::string, std::vector<std::unique_ptr<osgEarth::ImGuiPanel> > > menus_;
+#else
   std::map<std::string, std::vector<std::unique_ptr<osgEarth::GUI::BaseGUI> > > menus_;
+#endif
+
   std::vector<std::unique_ptr<::GUI::BaseGui> > deprecatedGuis_;
 
   ImFont* defaultFont_;

--- a/Examples/imgui/SimExamplesGui.cpp
+++ b/Examples/imgui/SimExamplesGui.cpp
@@ -20,14 +20,12 @@
  * disclose, or release this software.
  *
  */
-#include "imgui.h"
-#include "osgEarth/ImGui/ImGui"
 #include "SimExamplesGui.h"
 
 namespace simExamples {
 
 SimExamplesGui::SimExamplesGui(const std::string& name)
-  : osgEarth::GUI::BaseGUI(name.c_str()),
+  : OSGEARTH_GUI_BASE_CLASS(name.c_str()),
   firstDraw_(true),
   defaultFont_(nullptr),
   largeFont_(nullptr),

--- a/Examples/imgui/SimExamplesGui.h
+++ b/Examples/imgui/SimExamplesGui.h
@@ -25,9 +25,18 @@
 
 #include "imgui.h"
 #include "imgui_internal.h"
-#include "osgEarth/ImGui/ImGui"
 #include <functional>
 #include <string>
+
+#include "osgEarth/BuildConfig"
+#ifdef OSGEARTH_HAVE_IMGUI_NODEKIT
+  #include "osgEarthImGui/ImGuiPanel"
+  #define OSGEARTH_GUI_BASE_CLASS osgEarth::ImGuiPanel
+#else
+  #include "osgEarth/ImGui/ImGui"
+  #define OSGEARTH_GUI_BASE_CLASS osgEarth::GUI::BaseGUI
+#endif
+
 
 struct ImFont;
 namespace osg { class RenderInfo; }
@@ -35,7 +44,7 @@ namespace osg { class RenderInfo; }
 namespace simExamples {
 
 /** Base class for an ImGui GUI window */
-class SimExamplesGui : public osgEarth::GUI::BaseGUI
+class SimExamplesGui : public OSGEARTH_GUI_BASE_CLASS
 {
 public:
   virtual ~SimExamplesGui();


### PR DESCRIPTION
For osgEarth 3.6 (SO 159) osgEarth has a new osgEarthImGui nodekit - this PR updates the SDK's use of include files and namespaces to continue using the osgEarth built-in GUI panels while retaining SIMSDK's internally embedded imgui. Tested on Windows