### PR TITLE
Update CMake path for VsiPackages.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 include(PublicDefaults)
 # Include specific defaults for building with VSI environment
 include(VsiDefaults)
-vsi_process_packages_json(${CMAKE_SOURCE_DIR}/CMakeUtilities/VsiPackages.json)
+vsi_process_packages_json(${PROJECT_SOURCE_DIR}/CMakeUtilities/VsiPackages.json)
 
 # Build Release mode by default on Linux, unless otherwise specified
 include(DefaultToReleaseBuildType)


### PR DESCRIPTION
CMAKE_SOURCE_DIR does not work if the CMakeLists.txt here is being called from another CMakeLists.txt, i.e. if someone were to add_subdirectory this repository. The path to the json will stem from the wrong CMakeLists.txt. Switching it to PROJECT_SOURCE_DIR makes the path relative to this specific CMakeLists.txt.