### PR TITLE
add option USE_VCPKG_SIMDISSDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ else()
     remove_definitions(-DUSE_DEPRECATED_SIMDISSDK_API)
 endif()
 
+# Option to use simdissdk from vcpkg instead of building from source
+option(USE_VCPKG_SIMDISSDK "Use simdissdk from vcpkg instead of building from source" OFF)
+
 # Static build for libraries?
 option(SIMNOTIFY_SHARED "If off, simNotify SDK libraries are built statically; if on, simNotify SDK libraries are built dynamically" ON)
 option(SIMCORE_SHARED "If off, simCore SDK libraries are built statically; if on, simCore SDK libraries are built dynamically" ON)
@@ -237,7 +240,10 @@ find_package(GLCORE)
 # --- osgEarth -----------------------------
 
 # subprojects
-add_subdirectory(SDK)
+if(NOT USE_VCPKG_SIMDISSDK)
+    add_subdirectory(SDK)
+endif()
+
 option(BUILD_SDK_EXAMPLES "Build SIMDIS SDK Example Applications" ON)
 if(BUILD_SDK_EXAMPLES)
     add_subdirectory(Examples)

--- a/CMakeModules/HelperFunctions.cmake
+++ b/CMakeModules/HelperFunctions.cmake
@@ -413,6 +413,11 @@ function(vsi_install_target TARGET COMPONENT)
     get_target_property(IS_IMPORTED ${TARGET} IMPORTED)
     if(TARGET_TYPE STREQUAL "EXECUTABLE")
         vsi_install_executable(${TARGET} ${COMPONENT})
+        
+        # Set up OSGEARTH plugin directory for executables
+        if(WIN32 AND COMMAND setup_osgearth_plugin_dir)
+            setup_osgearth_plugin_dir(${TARGET})
+        endif()
     elseif(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
         if(IS_IMPORTED)
             vsi_install_imported_shared_library(${TARGET} ${COMPONENT})

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -2,6 +2,69 @@
 
 project(SIMDIS_SDK_Examples)
 
+# USE_VCPKG_SIMDISSDK is automatically passed to subdirectories
+
+if(USE_VCPKG_SIMDISSDK)
+    message(STATUS "Using vcpkg's simdissdk in Examples")
+    # Use the individual CMake config files for each library
+    find_package(simCore CONFIG REQUIRED)
+    find_package(simData CONFIG REQUIRED)
+    find_package(simNotify CONFIG REQUIRED)
+    find_package(simQt CONFIG REQUIRED)
+    find_package(simUtil CONFIG REQUIRED)
+    find_package(simVis CONFIG REQUIRED)
+    # Set up aliases for the library na
+    add_library(simCore ALIAS VSI::simCore)
+    add_library(simData ALIAS VSI::simData)
+    add_library(simNotify ALIAS VSI::simNotify)
+    add_library(simQt ALIAS VSI::simQt)
+    add_library(simUtil ALIAS VSI::simUtil)
+    add_library(simVis ALIAS VSI::simVis)
+endif()
+
+# Set up OSGEARTH plugin directory
+if(WIN32)
+    # Set OSG plugin paths
+    # For vcpkg, plugins are in plugins directory, not lib directory
+    # Note: OSG will automatically look for osgPlugins-<version> subdirectory
+    if(USE_VCPKG_SIMDISSDK AND DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+        SET(OSG_PLUGINS_DIR "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/plugins")
+        SET(OSG_PLUGINS_DIR_DEBUG "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/plugins")
+        message(STATUS "OSG_PLUGINS_DIR=${OSG_PLUGINS_DIR}")
+        message(STATUS "OSG_PLUGINS_DIR_DEBUG=${OSG_PLUGINS_DIR_DEBUG}")
+    endif()
+    
+    # Function to set up OSGEARTH plugin directory for each example
+    function(setup_osgearth_plugin_dir TARGET_NAME)
+        if(OSG_PLUGINS_DIR)
+            # Set Visual Studio debugger environment variables
+            # VS_DEBUGGER_ENVIRONMENT: Sets the 'Environment' property for debugging
+            # Use debug paths for debug builds if available
+            
+            # Check if debug directories exist
+            SET(USE_DEBUG_PATHS FALSE)
+            IF(OSG_PLUGINS_DIR_DEBUG)
+                IF(EXISTS "${OSG_PLUGINS_DIR_DEBUG}")
+                    SET(USE_DEBUG_PATHS TRUE)
+                ENDIF()
+            ENDIF()
+            
+            IF(USE_DEBUG_PATHS)
+                # For vcpkg, use debug paths (which contain the 'd' suffixed DLLs)
+                # Use semicolon to separate multiple paths in PATH variable
+                SET(OSG_ENVIRONMENT "OSG_LIBRARY_PATH=${OSG_PLUGINS_DIR_DEBUG};${OSG_PLUGINS_DIR}")
+                message(STATUS "Example ${TARGET_NAME}: Using Debug plugin paths")
+            ELSE()
+                SET(OSG_ENVIRONMENT "OSG_LIBRARY_PATH=${OSG_PLUGINS_DIR}")
+                message(STATUS "Example ${TARGET_NAME}: Using Release plugin paths")
+            ENDIF()
+            
+            SET_PROPERTY(TARGET ${TARGET_NAME} PROPERTY VS_DEBUGGER_ENVIRONMENT "${OSG_ENVIRONMENT}")
+            message(STATUS "Example ${TARGET_NAME}: VS_DEBUGGER_ENVIRONMENT=${OSG_ENVIRONMENT}")
+        endif()
+    endfunction()
+endif()
+
 add_subdirectory(imgui)
 
 add_subdirectory(AnimatedLine)

--- a/Examples/imgui/CMakeLists.txt
+++ b/Examples/imgui/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT TARGET simVis OR NOT TARGET osgEarth::osgEarth OR NOT TARGET OpenGL::GL)
+if(NOT TARGET osgEarth::osgEarth OR NOT TARGET OpenGL::GL)
     return()
 endif()
 
@@ -8,40 +8,51 @@ if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
     return()
 endif()
 
-# Add the local Dear ImGui to the search path at the end. This way, your own
-# Dear ImGui if it exists ought to be found first.
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_CURRENT_SOURCE_DIR}/1.92")
-# Prepend the user's environment variable, to prefer it first
-if(DEFINED ENV{IMGUI_DIR})
-    set(CMAKE_PREFIX_PATH "$ENV{IMGUI_DIR};${CMAKE_PREFIX_PATH}")
+if(USE_VCPKG_SIMDISSDK)
+    # Use vcpkg's imgui
+    message(STATUS "Using vcpkg's imgui")
+    find_package(imgui CONFIG REQUIRED)
+    add_library(VSI::imgui_gl3 ALIAS imgui::imgui)
+    # Create a backends directory structure for vcpkg imgui
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/backends")
+    file(COPY "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/imgui_impl_opengl3.h" DESTINATION "${CMAKE_BINARY_DIR}/backends/")
+    file(COPY "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/imgui_impl_opengl3_loader.h" DESTINATION "${CMAKE_BINARY_DIR}/backends/")
+else()
+    # Add the local Dear ImGui to the search path at the end. This way, your own
+    # Dear ImGui if it exists ought to be found first.
+    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_CURRENT_SOURCE_DIR}/1.92")
+    # Prepend the user's environment variable, to prefer it first
+    if(DEFINED ENV{IMGUI_DIR})
+        set(CMAKE_PREFIX_PATH "$ENV{IMGUI_DIR};${CMAKE_PREFIX_PATH}")
+    endif()
+
+    # Let user override with either CMAKE_PREFIX_PATH, or IMGUI_DIR environment variable
+    find_path(ImGui_DIR NAMES imgui.h)
+
+    # Must have ImGui_DIR defined to move past this point
+    if(NOT ImGui_DIR)
+        return()
+    endif()
+
+    add_library(imgui_gl3 STATIC
+        ${ImGui_DIR}/imgui.h
+        ${ImGui_DIR}/imgui.cpp
+        ${ImGui_DIR}/imgui_demo.cpp
+        ${ImGui_DIR}/imgui_draw.cpp
+        ${ImGui_DIR}/imgui_tables.cpp
+        ${ImGui_DIR}/imgui_widgets.cpp
+        ${ImGui_DIR}/backends/imgui_impl_opengl3.h
+        ${ImGui_DIR}/backends/imgui_impl_opengl3.cpp
+        ${ImGui_DIR}/backends/imgui_impl_opengl3_loader.h
+    )
+    target_include_directories(imgui_gl3 PUBLIC "${ImGui_DIR}")
+    target_link_libraries(imgui_gl3 PUBLIC OpenGL::GL PRIVATE ${CMAKE_DL_LIBS})
+    add_library(VSI::imgui_gl3 ALIAS imgui_gl3)
+    set_target_properties(imgui_gl3 PROPERTIES
+        FOLDER "Dear ImGui"
+        PROJECT_LABEL "Dear ImGui"
+    )
 endif()
-
-# Let user override with either CMAKE_PREFIX_PATH, or IMGUI_DIR environment variable
-find_path(ImGui_DIR NAMES imgui.h)
-
-# Must have ImGui_DIR defined to move past this point
-if(NOT ImGui_DIR)
-    return()
-endif()
-
-add_library(imgui_gl3 STATIC
-    ${ImGui_DIR}/imgui.h
-    ${ImGui_DIR}/imgui.cpp
-    ${ImGui_DIR}/imgui_demo.cpp
-    ${ImGui_DIR}/imgui_draw.cpp
-    ${ImGui_DIR}/imgui_tables.cpp
-    ${ImGui_DIR}/imgui_widgets.cpp
-    ${ImGui_DIR}/backends/imgui_impl_opengl3.h
-    ${ImGui_DIR}/backends/imgui_impl_opengl3.cpp
-    ${ImGui_DIR}/backends/imgui_impl_opengl3_loader.h
-)
-target_include_directories(imgui_gl3 PUBLIC "${ImGui_DIR}")
-target_link_libraries(imgui_gl3 PUBLIC OpenGL::GL PRIVATE ${CMAKE_DL_LIBS})
-add_library(VSI::imgui_gl3 ALIAS imgui_gl3)
-set_target_properties(imgui_gl3 PROPERTIES
-    FOLDER "Dear ImGui"
-    PROJECT_LABEL "Dear ImGui"
-)
 
 # Set up the ImGuiLib, based on ImGui
 set(SOURCE_FILES
@@ -55,6 +66,12 @@ set(SOURCE_FILES
 
 add_library(ImGuiLib ${SOURCE_FILES})
 target_include_directories(ImGuiLib PUBLIC .)
+# Add binary directory to include path so we can use #include "backends/imgui_impl_opengl3.h" for vcpkg
+if(USE_VCPKG_SIMDISSDK)
+    target_include_directories(ImGuiLib PRIVATE "${CMAKE_BINARY_DIR}")
+else()
+    target_include_directories(ImGuiLib PRIVATE "${ImGui_DIR}")
+endif()
 target_link_libraries(ImGuiLib PUBLIC osgEarth::osgEarth VSI::imgui_gl3 PRIVATE simVis simCore simNotify)
 if(CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(ImGuiLib PRIVATE -fno-strict-aliasing)


### PR DESCRIPTION
hi there,
i want to build the examples using the simdissdk in vcpkg,
then i add this option.

after make all examples run,
i found that a lot of file needed is not loaded.
i download the SIMDIS_SDK-Data.zip
at here https://github.com/USNavalResearchLaboratory/simdissdk/releases/tag/simdissdk-1.23
unzip it and point SIMDIS_SDK_FILE_PATH to the unzipped dir,
but the examples look for some files that are not  in the unzipped dir.
where should i find thoese files?
